### PR TITLE
add the kernelid to the tooltip and label to reflect the pod

### DIFF
--- a/packages/running-extension/src/kernels.ts
+++ b/packages/running-extension/src/kernels.ts
@@ -68,16 +68,21 @@ export function addKernelRunningSessionManager(
       return fileIcon;
     }
     label() {
-      return this._model.name || PathExt.basename(this._model.path);
+      let label = this._model.name || PathExt.basename(this._model.path);
+      if (this._model.id == this._model.kernel?.id) {
+        return label + ' (pending)'
+      }
+      return label + ' (nb-' + this._model.kernel?.id + ')';
     }
     labelTitle() {
       const { kernel, path } = this._model;
       let kernelName = kernel?.name;
+      let kernelId = kernel?.id;
       if (kernelName && specsManager.specs) {
         const spec = specsManager.specs.kernelspecs[kernelName];
         kernelName = spec ? spec.display_name : 'unknown';
       }
-      return trans.__('Path: %1\nKernel: %2', path, kernelName);
+      return trans.__('Path: %1\nKernel: %2\nKernel id: %3', path, kernelName, kernelId);
     }
 
     private _model: Session.IModel;


### PR DESCRIPTION
add the kernelid to the tooltip and label to reflect the corresponding pod

## Jira ticket

https://spotinst.atlassian.net/browse/BGD-4332

## Checklist
- [x] I added a Jira ticket link
- [x] I added a changeset with the `simple-changeset add` command
- [x] I filled in the test plan
- [x] I executed the tests and filled in the test results

## Why

We want to be able to see the corresponding pod running the kernel

## What

Added kernelid (part of the pod name) to the tooltip and kernel label
