### PR TITLE
dont use websocket protocol for jeg backward compatibility and fix ke…

### DIFF
--- a/packages/running/src/index.tsx
+++ b/packages/running/src/index.tsx
@@ -192,13 +192,13 @@ function Item(props: {
             ) : (
               <caretDownIcon.react tag="span" stylesheet="runningItem" />
             ))}
-          {typeof icon === 'string' ? (
-            icon ? (
+          {icon ? (
+            typeof icon === 'string' ? (
               <img src={icon} />
-            ) : undefined
-          ) : (
-            <icon.react tag="span" stylesheet="runningItem" />
-          )}
+            ) : (
+              <icon.react tag="span" stylesheet="runningItem"/>
+            )
+          ) : undefined}
           <span
             className={ITEM_LABEL_CLASS}
             title={title}

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1233,7 +1233,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
   /**
    * Create the kernel websocket connection and add socket status handlers.
    */
-  private _createSocket = (useProtocols = true) => {
+  private _createSocket = (useProtocols = false) => {
     this._errorIfDisposed();
 
     // Make sure the socket is clear

--- a/packages/services/src/session/restapi.ts
+++ b/packages/services/src/session/restapi.ts
@@ -112,7 +112,7 @@ export async function startSession(
   };
   let data = {"id": "", "execution_state": "waiting"};
   let count = 0
-  while (count++ < 600) {
+  while (count++ < 300) {
     const response = await ServerConnection.makeRequest(url, init, settings);
     if (response.status !== 201) {
       throw await ServerConnection.ResponseError.create(response);


### PR DESCRIPTION
dont use websocket protocol for jeg backward compatibility

## Jira ticket

https://spotinst.atlassian.net/browse/BGD-4393

## Checklist
- [x] I added a Jira ticket link
- [x] I added a changeset with the `simple-changeset add` command
- [x] I filled in the test plan
- [x] I executed the tests and filled in the test results

## Why

The enterprise gateway doesn't support the new v1 websocket kernel protocol. Default to no protocol until we have an updated version of JEG. FIx the kernel view for non existing icons

## What

Return undefined for non existing icons and use no protocol by default in kernel websocket connections

## How to test

A kernel entry should appear in the kernel list UI for remote kernels like in jupyterlab 3