### PR TITLE
move ocean specific code to 4.1.0

### DIFF
--- a/dev_mode/package.json
+++ b/dev_mode/package.json
@@ -97,7 +97,7 @@
     "@jupyterlab/rendermime-interfaces": "~3.9.0",
     "@jupyterlab/running": "~4.1.0",
     "@jupyterlab/running-extension": "~4.1.0",
-    "@jupyterlab/services": "~7.1.0",
+    "@jupyterlab/services": "../packages/services",
     "@jupyterlab/settingeditor": "~4.1.0",
     "@jupyterlab/settingeditor-extension": "~4.1.0",
     "@jupyterlab/settingregistry": "~4.1.0",

--- a/jupyterlab/semver.py
+++ b/jupyterlab/semver.py
@@ -747,6 +747,9 @@ def make_range(range_, loose):
 
 class Range:
     def __init__(self, range_, loose):
+        if "/services" in range_:
+            range_ = "~7.1.0"
+
         self.loose = loose
         #  First, split based on boolean or ||
         self.raw = range_

--- a/jupyterlab/staging/package.json
+++ b/jupyterlab/staging/package.json
@@ -97,7 +97,7 @@
     "@jupyterlab/rendermime-interfaces": "~3.9.0",
     "@jupyterlab/running": "~4.1.0",
     "@jupyterlab/running-extension": "~4.1.0",
-    "@jupyterlab/services": "~7.1.0",
+    "@jupyterlab/services": "../../packages/services",
     "@jupyterlab/settingeditor": "~4.1.0",
     "@jupyterlab/settingeditor-extension": "~4.1.0",
     "@jupyterlab/settingregistry": "~4.1.0",

--- a/packages/services/src/kernel/default.ts
+++ b/packages/services/src/kernel/default.ts
@@ -1235,7 +1235,7 @@ export class KernelConnection implements Kernel.IKernelConnection {
   /**
    * Create the kernel websocket connection and add socket status handlers.
    */
-  private _createSocket = (useProtocols = true) => {
+  private _createSocket = (useProtocols = false) => {
     this._errorIfDisposed();
 
     // Make sure the socket is clear

--- a/packages/services/src/session/restapi.ts
+++ b/packages/services/src/session/restapi.ts
@@ -96,6 +96,9 @@ export async function getSessionModel(
   return data;
 }
 
+function sleep(ms: number | undefined) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 /**
  * Create a new session, or return an existing session if the session path
  * already exists.
@@ -105,16 +108,45 @@ export async function startSession(
   settings: ServerConnection.ISettings = ServerConnection.makeSettings()
 ): Promise<Session.IModel> {
   const url = URLExt.join(settings.baseUrl, SESSION_SERVICE_URL);
-  const init = {
+  const body = JSON.stringify(options);
+  const bodyjson = JSON.parse(body);
+  bodyjson['id'] = '';
+  let init = {
     method: 'POST',
-    body: JSON.stringify(options)
+    body: JSON.stringify(bodyjson)
   };
-  const response = await ServerConnection.makeRequest(url, init, settings);
-  if (response.status !== 201) {
-    const err = await ServerConnection.ResponseError.create(response);
-    throw err;
+  let data = { id: '', execution_state: 'waiting' };
+  let count = 0;
+  while (count++ < 300) {
+    const response = await ServerConnection.makeRequest(url, init, settings);
+    if (response.status !== 201) {
+      throw await ServerConnection.ResponseError.create(response);
+    }
+    data = await response.json();
+    if (data.execution_state != 'waiting') {
+      console.log(
+        'Kernel started in session ' + data.id + ' after ' + count + ' seconds'
+      );
+      break;
+    } else {
+      bodyjson['id'] = data.id;
+      init = {
+        method: 'POST',
+        body: JSON.stringify(bodyjson)
+      };
+      await sleep(2000);
+      console.log(
+        'Waiting for kernel in session ' +
+          data.id +
+          ' for ' +
+          2 * count +
+          ' seconds'
+      );
+    }
   }
-  const data = await response.json();
+  if (count >= 300) {
+    throw new Error('10 minute timeout waiting for kernel to start');
+  }
   updateLegacySessionModel(data);
   validateModel(data);
   return data;


### PR DESCRIPTION
## Jira ticket

https://spotinst.atlassian.net/browse/BGD-4696

## Checklist
- [x] I added a Jira ticket link
- [x] I added a changeset with the `simple-changeset add` command
- [ ] I filled in the test plan
- [ ] I executed the tests and filled in the test results

## Why

Support the new v4.1.x line of Jupyterlab

## What

Branched from tag 4.1.0. Applied ocean changes in 4.0.x-ocean.

## How to test

Run workspaces