### PR TITLE
use jupyter server sha with fixes for switching kernel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "ipykernel>=6.5.0",
     "jinja2>=3.0.3",
     "jupyter_core",
-    "jupyter_server@git+https://github.com/spotinst/jupyter_server.git@846e3fb",
+    "jupyter_server@git+https://github.com/spotinst/jupyter_server.git@5653074",
     "jupyter-lsp>=2.0.0",
     "jupyterlab_server>=2.27.1,<3",
     "notebook_shim>=0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "ipykernel>=6.5.0",
     "jinja2>=3.0.3",
     "jupyter_core",
-    "jupyter_server@git+https://github.com/spotinst/jupyter_server.git@5653074",
+    "jupyter_server@git+https://github.com/spotinst/jupyter_server.git@ddf0b98",
     "jupyter-lsp>=2.0.0",
     "jupyterlab_server>=2.27.1,<3",
     "notebook_shim>=0.2",


### PR DESCRIPTION
## Jira ticket

https://spotinst.atlassian.net/browse/BGD-5953

## Checklist
- [x] I added a Jira ticket link
- [x] I added a changeset with the `simple-changeset add` command
- [x] I filled in the test plan
- [x] I executed the tests and filled in the test results

## Why

Switching kernels was broken when using pseudo waiting kernel to prevent timeouts

## What

Ignore kernel_id "waiting" in all cases. Previously "waiting" kernel was saved to sqlite db to be fetched again and treated like a normal kernel

## How to test

Run a workspace with jupyterlab image with these changes (edit deployment). Run one of the config templates and wait until the notebook spark application is running. Switch to another config template in the upper right corner. The previous application should be killed and a new one with the selected config should be launched and connected

<img width="1207" alt="Screenshot 2024-10-08 at 10 09 42" src="https://github.com/user-attachments/assets/ebabaa06-1027-4aae-bc74-9b0eeaacdee2">

## Test plan and results

Ran the above and switches kernels two more times.
