### PR TITLE
added pseudo kernel handling in updateSession

### DIFF
--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -391,10 +391,16 @@ export class SessionConnection implements Session.ISessionConnection {
   private async _patch(
     body: DeepPartial<Session.IModel>
   ): Promise<Session.IModel> {
-    const model = await updateSession(
-      { ...body, id: this._id },
-      this.serverSettings
-    );
+    this._updating = true;
+    let model: Session.IModel;
+    try {
+      model = await updateSession(
+        {...body, id: this._id},
+        this.serverSettings
+      );
+    } finally {
+      this._updating = false;
+    }
     this.update(model);
     return model;
   }
@@ -422,6 +428,7 @@ export class SessionConnection implements Session.ISessionConnection {
   private _clientId: string;
   private _kernel: Kernel.IKernelConnection | null = null;
   private _isDisposed = false;
+  private _updating = false;
   private _disposed = new Signal<this, void>(this);
   private _kernelChanged = new Signal<
     this,

--- a/packages/services/src/session/default.ts
+++ b/packages/services/src/session/default.ts
@@ -209,7 +209,7 @@ export class SessionConnection implements Session.ISessionConnection {
    * Dispose of the resources held by the session.
    */
   dispose(): void {
-    if (this.isDisposed) {
+    if (this._updating || this.isDisposed) {
       return;
     }
     this._isDisposed = true;

--- a/packages/services/src/session/restapi.ts
+++ b/packages/services/src/session/restapi.ts
@@ -160,16 +160,45 @@ export async function updateSession(
   settings: ServerConnection.ISettings = ServerConnection.makeSettings()
 ): Promise<Session.IModel> {
   const url = getSessionUrl(settings.baseUrl, model.id);
-  const init = {
+  const body = JSON.stringify(model);
+  const bodyjson = JSON.parse(body);
+  bodyjson['id'] = '';
+  let init = {
     method: 'PATCH',
     body: JSON.stringify(model)
   };
-  const response = await ServerConnection.makeRequest(url, init, settings);
-  if (response.status !== 200) {
-    const err = await ServerConnection.ResponseError.create(response);
-    throw err;
+  let data = { id: '', execution_state: 'waiting' };
+  let count = 0;
+  while (count++ < 300) {
+    const response = await ServerConnection.makeRequest(url, init, settings);
+    if (response.status !== 200 && response.status !== 201) {
+      throw await ServerConnection.ResponseError.create(response);
+    }
+    data = await response.json();
+    if (data.execution_state != 'waiting') {
+      console.log(
+        'Kernel started in update session ' + data.id + ' after ' + count + ' seconds'
+      );
+      break;
+    } else {
+      bodyjson['id'] = data.id;
+      init = {
+        method: 'PATCH',
+        body: JSON.stringify(bodyjson)
+      };
+      await sleep(2000);
+      console.log(
+        'Waiting for kernel in update session ' +
+        data.id +
+        ' for ' +
+        2 * count +
+        ' seconds'
+      );
+    }
   }
-  const data = await response.json();
+  if (count >= 300) {
+    throw new Error('10 minute timeout waiting for updated kernel to start');
+  }
   updateLegacySessionModel(data);
   validateModel(data);
   return data;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "ipykernel>=6.5.0",
     "jinja2>=3.0.3",
     "jupyter_core",
-    "jupyter_server@git+https://github.com/spotinst/jupyter_server.git@ocean-spark-jupyterserver-jlab",
+    "jupyter_server@git+https://github.com/spotinst/jupyter_server.git@ddf0b98",
     "jupyter-lsp>=2.0.0",
     "jupyterlab_server>=2.27.1,<3",
     "notebook_shim>=0.2",


### PR DESCRIPTION
## Jira ticket

https://spotinst.atlassian.net/browse/BGD-5953

## Checklist
- [x] I added a Jira ticket link
- [x] I added a changeset with the `simple-changeset add` command
- [x] I filled in the test plan
- [x] I executed the tests and filled in the test results

## Why

Switching kernels was broken when using pseudo waiting kernel to prevent timeouts

## What

Ignore kernel_id "waiting" in all cases. Previously "waiting" kernel was saved to sqlite db to be fetched again and treated like a normal kernel

## How to test

Run a workspace with jupyterlab image with these changes (edit deployment). Run one of the config templates and wait until the notebook spark application is running. Switch to another config template in the upper right corner. The previous application should be killed and a new one with the selected config should be launched and connected

<img width="1207" alt="Screenshot 2024-10-08 at 10 09 42" src="https://github.com/user-attachments/assets/ebabaa06-1027-4aae-bc74-9b0eeaacdee2">

## Test plan and results

Ran the above and switches kernels two more times.
