### PR TITLE
[BGD-6236] enableKernelInitNotification true by default

### DIFF
--- a/packages/notebook-extension/schema/tracker.json
+++ b/packages/notebook-extension/schema/tracker.json
@@ -675,7 +675,7 @@
       "title": "Notify about code execution if kernel is initializing",
       "description": "Display notification if code cells are run while kernel is initializing.",
       "type": "boolean",
-      "default": false
+      "default": true
     },
     "codeCellConfig": {
       "title": "Code Cell Configuration",


### PR DESCRIPTION
## Jira ticket

https://spotinst.atlassian.net/browse/BGD-6236

## Checklist
- [x] I added a Jira ticket link
- [x] ~~I added a changeset with the `simple-changeset add` command~~
- [x] I filled in the test plan
- [x] I executed the tests and filled in the test results

## Why

we want the notification to display to help users 

## What

set `enableKernelInitNotification` to true by default

## How to test

Install and run locally
- Check settings to see if it is set to true
- Start a notebook and try to run a cell while the kernel is initializing, it should display the notification

## Test plan and results

| Test | Description       | Result | Notes                      |
|------|-------------------|--------|----------------------------|
| 1    | Settings is true by default | Pass   | see screenshots  |
| 2    | Notification is displayed | Pass   | Some notes about the test  |

<img width="635" alt="Screenshot 2024-12-10 at 10 28 49" src="https://github.com/user-attachments/assets/4538b628-bae4-481b-ad4d-a2177c20db2d">
<img width="842" alt="Screenshot 2024-12-10 at 10 29 16" src="https://github.com/user-attachments/assets/e27e761b-90bc-46de-b598-09723f44c3ee">
<img width="491" alt="Screenshot 2024-12-10 at 11 01 59" src="https://github.com/user-attachments/assets/7ea68993-70c1-4f76-9094-c4dcec76f477">

